### PR TITLE
Remove type for $identity

### DIFF
--- a/includes/Hooks/RestHooks.php
+++ b/includes/Hooks/RestHooks.php
@@ -62,7 +62,7 @@ class RestHooks implements SearchResultProvideDescriptionHook {
 		array $pageIdentities,
 		&$descriptions
 	):void {
-		$pageIdTitles = array_map( function ( SearchResultPageIdentity $identity ) {
+		$pageIdTitles = array_map( function ( $identity ) {
 			return Title::makeTitle( $identity->getNamespace(), $identity->getDBkey() );
 		}, $pageIdentities );
 


### PR DESCRIPTION
Under mw 1.37 it's failing with "Argument 1 passed to MediaWiki\Extension\ShortDescription\Hooks\RestHooks::MediaWiki\Extension\ShortDescription\Hooks\{closure}() must be an instance of MediaWiki\Rest\Entity\SearchResultPageIdentity, instance of MediaWiki\Page\PageIdentityValue given".