### PR TITLE
Use namespaced GlobalVarConfig

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -81,7 +81,7 @@
 		}
 	},
 	"ConfigRegistry": {
-		"shortdescription": "GlobalVarConfig::newInstance"
+		"shortdescription": "MediaWiki\\Config\\GlobalVarConfig::newInstance"
 	},
 	"manifest_version": 2
 }


### PR DESCRIPTION
The non-namespaced class alias was deprecated in MW 1.41. See also https://phabricator.wikimedia.org/T402038