### PR TITLE
Update to modern convention

### DIFF
--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,0 +1,2 @@
+vendor/
+node_modules/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,77 @@
+# AGENTS.md
+
+## Overview
+
+ShortDescription is a MediaWiki extension (requires MW 1.43+) that adds a `{{SHORTDESC:...}}` magic word and exposes the stored description through hooks (`OutputPageParserOutput`, `BeforePageDisplay`, `InfoAction`, `SearchResultProvideDescription`) and an API module (`prop=description`). It can also feed OpenSearch suggestions and render the description as a site tagline. PHP for parsing/storage and the API, vanilla JS + LESS for the optional tagline rendering via ResourceLoader.
+
+## Verification
+
+Run only what's relevant to the files you changed.
+
+| Files changed | Command |
+| --- | --- |
+| `*.php` | `composer preflight` (lint, style, and Phan) |
+| `*.js` | `npm run lint:js` |
+| `*.less`, `*.css` | `npm run lint:styles` |
+| `i18n/` | `npm run lint:i18n` |
+
+Auto-fix commands: `composer fix` (PHP), `npm run lint:fix:js` (JS), `npm run lint:fix:styles` (styles).
+
+**Preflight**: Run `npm run preflight` to execute all Node-based lints in one command. Run `composer preflight` from within a MediaWiki installation to execute all PHP lints, style checks, and Phan static analysis.
+
+**Always run the relevant checks before committing.** Read the full output — PHPCS warnings must be fixed, not just errors. The command exits 0 even with warnings, so do not treat exit code alone as a pass.
+
+### Dev environment
+
+This project's standard dev environment is the MediaWiki Docker setup defined in the parent `mediawiki/` directory. The user may be using a different environment. Ask the user for their dev environment URL and how to run commands if not already known.
+
+To run composer commands in the standard Docker environment:
+
+```sh
+docker compose exec mediawiki bash -c "cd /var/www/html/w/extensions/ShortDescription && composer preflight"
+```
+
+### Phan
+
+Phan requires a full MediaWiki installation at `../../` for type resolution.
+
+```sh
+docker compose exec mediawiki bash -c "cd /var/www/html/w/extensions/ShortDescription && composer phan"
+```
+
+## Coding conventions
+
+### PHP
+
+- New files start with `declare( strict_types=1 );`
+- Use native PHP types (properties, parameters, return values); use PHPDoc only for collection types like `string[]`
+- Always use MediaWiki-namespaced imports (`use MediaWiki\Title\Title;`), never legacy shims (`use Title;`)
+- Hook handlers live under `includes/Hooks/` and are wired through `HookHandlers` in `extension.json`
+
+### JavaScript
+
+- CommonJS modules: `require()` for imports, `module.exports` for exports
+- Client code lives in `modules/`
+
+### LESS/CSS
+
+- Styles live in `modules/`
+- Class names follow the `ext-shortdesc` prefix pattern (enforced by `.stylelintrc.json`)
+
+### extension.json
+
+`extension.json` is the source of truth for how the extension is wired — ResourceLoader modules, hooks, config variables, API modules, and dependencies are all declared here.
+
+- When adding or removing files under `modules/`, update the corresponding `scripts` or `styles` list in `ResourceModules`
+- Config variables are declared under `config` in `extension.json` (prefixed `wgShortDescription`)
+- New hooks must be registered under both `Hooks` and `HookHandlers`
+
+### Commits
+
+- Use [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `fix:`, `feat:`, `refactor:`)
+- Use `ci:` or `chore:` for non-user-facing changes (tooling, config, dependencies)
+
+### i18n
+
+- Any user-facing string needs a message key in `i18n/en.json` (or `i18n/api/en.json` for API-only messages)
+- Every key in `en.json` must also have a documentation entry in the matching `qqq.json`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/composer.json
+++ b/composer.json
@@ -33,15 +33,23 @@
 	},
 	"scripts": {
 		"fix": [
-			"minus-x fix ."
+			"minus-x fix .",
+			"phpcbf"
 		],
 		"test": [
 			"parallel-lint . --exclude vendor --exclude node_modules",
-			"phpcs --config-set ignore_warnings_on_exit 1",
-			"phpcs -p -s",
+			"@phpcs",
 			"minus-x check ."
 		],
-		"phan": "phan -d . --long-progress-bar"
+		"phan": "phan -d . --long-progress-bar",
+		"phpcs": [
+			"phpcs --config-set ignore_warnings_on_exit 1",
+			"phpcs -sp --cache"
+		],
+		"preflight": [
+			"@test",
+			"@phan"
+		]
 	},
 	"extra": {
 		"installer-name": "ShortDescription"

--- a/includes/Hooks/ActionsHooks.php
+++ b/includes/Hooks/ActionsHooks.php
@@ -11,6 +11,7 @@ declare( strict_types=1 );
 
 namespace MediaWiki\Extension\ShortDescription\Hooks;
 
+use MediaWiki\Context\IContextSource;
 use MediaWiki\Hook\InfoActionHook;
 
 class ActionsHooks implements InfoActionHook {

--- a/includes/Hooks/HookUtils.php
+++ b/includes/Hooks/HookUtils.php
@@ -10,6 +10,7 @@
 namespace MediaWiki\Extension\ShortDescription\Hooks;
 
 use MediaWiki\MediaWikiServices;
+use MediaWiki\Title\Title;
 
 class HookUtils {
 
@@ -20,7 +21,7 @@ class HookUtils {
 
 	/**
 	 * Returns pageprops array for short description
-	 * @param Title $title Title to get short description for
+	 * @param Title|Title[] $title Title (or array of page ID => Title) to get short description for
 	 * @return array PageProps for short description
 	 */
 	public static function getPageProps( $title ) {

--- a/includes/Hooks/PageHooks.php
+++ b/includes/Hooks/PageHooks.php
@@ -12,6 +12,8 @@ declare( strict_types=1 );
 namespace MediaWiki\Extension\ShortDescription\Hooks;
 
 use MediaWiki\Hook\BeforePageDisplayHook;
+use MediaWiki\Output\OutputPage;
+use Skin;
 
 class PageHooks implements BeforePageDisplayHook {
 

--- a/includes/Hooks/ParserHooks.php
+++ b/includes/Hooks/ParserHooks.php
@@ -13,6 +13,7 @@ namespace MediaWiki\Extension\ShortDescription\Hooks;
 
 use MediaWiki\Hook\ParserFirstCallInitHook;
 use MediaWiki\Output\Hook\OutputPageParserOutputHook;
+use MediaWiki\Output\OutputPage;
 use MediaWiki\Parser\Parser;
 use MediaWiki\Parser\ParserOutput;
 use MediaWiki\Title\Title;

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
 	"private": true,
 	"scripts": {
-		"lint": "npm -s run lint:js && npm -s run lint:i18n",
+		"lint": "npm -s run lint:js && npm -s run lint:styles && npm -s run lint:i18n",
 		"lint:fix:js": "npm -s run lint:js -- --fix",
 		"lint:fix:styles": "npm -s run lint:styles -- --fix",
 		"lint:js": "eslint --cache --max-warnings 0 .",
 		"lint:styles": "stylelint \"**/*.{less,css}\"",
-		"lint:i18n": "banana-checker --requireLowerCase=0 i18n/"
+		"lint:i18n": "banana-checker --requireLowerCase=0 i18n/",
+		"preflight": "npm run lint"
 	},
 	"devDependencies": {
 		"eslint-config-wikimedia": "0.32.4",


### PR DESCRIPTION
## Summary
- Adds `AGENTS.md` describing the repo layout, verification commands, and coding conventions for AI coding agents (mirrors the structure used in TabberNeue, scoped to ShortDescription).
- Adds `CLAUDE.md` as a single-line `@AGENTS.md` pointer so Claude Code picks the same content up.
- Adds `npm run preflight` and `composer preflight` to bundle the lint/style/Phan checks into one command per ecosystem; also adds the missing `lint:styles` step to the npm `lint` chain and adds `phpcbf` to `composer fix`.

## Test plan
- [x] `npm run preflight` passes locally
- [x] `composer preflight` passes inside the MediaWiki Docker dev environment (requires a full MW install for Phan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)