### PR TITLE
refactor: use PHP 8.1+ native types and modern syntax

### DIFF
--- a/includes/ApiQueryDescription.php
+++ b/includes/ApiQueryDescription.php
@@ -1,5 +1,7 @@
 <?php
 
+declare( strict_types=1 );
+
 namespace MediaWiki\Extension\ShortDescription;
 
 use MediaWiki\Api\ApiQuery;
@@ -24,28 +26,22 @@ use Wikimedia\ParamValidator\ParamValidator;
  */
 class ApiQueryDescription extends ApiQueryBase {
 
-	/**
-	 * @param ApiQuery $query
-	 * @param string $moduleName
-	 */
-	public function __construct(
-		ApiQuery $query,
-		$moduleName
-	) {
+	public function __construct( ApiQuery $query, string $moduleName ) {
 		parent::__construct( $query, $moduleName, 'desc' );
 	}
 
 	/**
 	 * @inheritDoc
 	 */
-	public function execute() {
-		$continue = $this->getParameter( 'continue' );
+	public function execute(): void {
+		$continue = (int)$this->getParameter( 'continue' );
 
 		$pages = $this->getPageSet()->getGoodPages();
 		$titlesByPageId = [];
 		foreach ( $pages as $pageId => $title ) {
 			$titlesByPageId[$pageId] = Title::newFromPageIdentity( $title );
 		}
+
 		// Just in case we are dealing with titles from some very fast generator,
 		// apply some limits as a sanity check.
 		$limit = $this->getMain()->canApiHighLimits() ? self::LIMIT_BIG2 : self::LIMIT_BIG1;
@@ -56,29 +52,28 @@ class ApiQueryDescription extends ApiQueryBase {
 
 		$descriptionsByPageId = Hooks\HookUtils::getDescriptionsByPageId( $titlesByPageId );
 
-		$this->addDataToResponse( array_keys( $titlesByPageId ),
-			$descriptionsByPageId, $continue );
+		$this->addDataToResponse( array_keys( $titlesByPageId ), $descriptionsByPageId, $continue );
 	}
 
 	/**
 	 * @param int[] $pageIds Page IDs, in the same order as returned by the ApiPageSet.
-	 * @param string[] $descriptionsByPageId Descriptions from wikitext, as an
-	 *   associative array of page ID
+	 * @param string[] $descriptionsByPageId Descriptions keyed by page ID.
 	 * @param int $continue The API request is being continued from this position.
 	 */
 	private function addDataToResponse(
 		array $pageIds,
 		array $descriptionsByPageId,
-		$continue
-	) {
+		int $continue
+	): void {
 		$result = $this->getResult();
 		$i = 0;
-		$fit = true;
 		foreach ( $pageIds as $pageId ) {
-			$path = [ 'query', 'pages', $pageId ];
-			if ( array_key_exists( $pageId, $descriptionsByPageId ) ) {
-				$fit = $result->addValue( $path, 'description', $descriptionsByPageId[$pageId] );
+			if ( !array_key_exists( $pageId, $descriptionsByPageId ) ) {
+				$i++;
+				continue;
 			}
+			$path = [ 'query', 'pages', $pageId ];
+			$fit = $result->addValue( $path, 'description', $descriptionsByPageId[$pageId] );
 			if ( !$fit ) {
 				$this->setContinueEnumParameter( 'continue', $continue + $i );
 				break;
@@ -90,14 +85,14 @@ class ApiQueryDescription extends ApiQueryBase {
 	/**
 	 * @inheritDoc
 	 */
-	public function getCacheMode( $params ) {
+	public function getCacheMode( $params ): string {
 		return 'public';
 	}
 
 	/**
 	 * @inheritDoc
 	 */
-	protected function getAllowedParams() {
+	protected function getAllowedParams(): array {
 		return [
 			'continue' => [
 				self::PARAM_HELP_MSG => 'api-help-param-continue',
@@ -110,11 +105,10 @@ class ApiQueryDescription extends ApiQueryBase {
 	/**
 	 * @inheritDoc
 	 */
-	protected function getExamplesMessages() {
+	protected function getExamplesMessages(): array {
 		return [
 			'action=query&prop=description&titles=London'
-			=> 'apihelp-query+description-example',
+				=> 'apihelp-query+description-example',
 		];
 	}
-
 }

--- a/includes/Hooks/ActionsHooks.php
+++ b/includes/Hooks/ActionsHooks.php
@@ -17,17 +17,16 @@ use MediaWiki\Hook\InfoActionHook;
 class ActionsHooks implements InfoActionHook {
 
 	/**
-	 * InfoAction hook handler, adds the short description to the info=action page
+	 * InfoAction hook handler, adds the short description to the info=action page.
 	 *
 	 * @see https://www.mediawiki.org/wiki/Manual:Hooks/InfoAction
 	 *
-	 * @param IContextSource $context Context, used to extract the title of the page
-	 * @param array[] &$pageInfo Auxillary information about the page.
+	 * @param IContextSource $context
+	 * @param array[] &$pageInfo Auxiliary information about the page.
 	 */
-	public function onInfoAction( $context, &$pageInfo ) {
+	public function onInfoAction( $context, &$pageInfo ): void {
 		$shortdesc = HookUtils::getShortDescription( $context->getTitle() );
 		if ( !$shortdesc ) {
-			// The page has no short description
 			return;
 		}
 

--- a/includes/Hooks/ApiHooks.php
+++ b/includes/Hooks/ApiHooks.php
@@ -19,12 +19,13 @@ use MediaWiki\Request\FauxRequest;
 class ApiHooks implements ApiOpenSearchSuggestHook {
 
 	/**
-	 * ApiOpenSearchSuggest hook handler
+	 * ApiOpenSearchSuggest hook handler.
+	 *
 	 * @see https://www.mediawiki.org/wiki/Manual:Hooks/ApiOpenSearchSuggest
 	 *
-	 * @param array &$results Array of search results
+	 * @param array<int,array<string,mixed>> &$results Array of search results, keyed by page ID.
 	 */
-	public function onApiOpenSearchSuggest( &$results ) {
+	public function onApiOpenSearchSuggest( &$results ): void {
 		if ( !HookUtils::getConfig( 'ShortDescriptionExtendOpenSearchXml' ) || !count( $results ) ) {
 			return;
 		}
@@ -51,7 +52,5 @@ class ApiHooks implements ApiOpenSearchSuggestHook {
 				$results[$id]['extract trimmed'] = false;
 			}
 		}
-
-		$pageIds = array_keys( $results );
 	}
 }

--- a/includes/Hooks/HookUtils.php
+++ b/includes/Hooks/HookUtils.php
@@ -7,6 +7,8 @@
  * @license MIT
  */
 
+declare( strict_types=1 );
+
 namespace MediaWiki\Extension\ShortDescription\Hooks;
 
 use MediaWiki\MediaWikiServices;
@@ -20,30 +22,29 @@ class HookUtils {
 	public const PROP_NAME = 'shortdesc';
 
 	/**
-	 * Returns pageprops array for short description
-	 * @param Title|Title[] $title Title (or array of page ID => Title) to get short description for
-	 * @return array PageProps for short description
+	 * Returns pageprops array for short description.
+	 *
+	 * @param Title|Title[] $title Single Title, or an array of page ID => Title.
+	 * @return array<int,string> PageProps for short description, keyed by page ID.
 	 */
-	public static function getPageProps( $title ) {
+	public static function getPageProps( Title|array $title ): array {
 		return MediaWikiServices::getInstance()->getPageProps()->getProperties( $title, self::PROP_NAME );
 	}
 
 	/**
-	 * Returns short description for a given title
-	 * @param Title $title Title to get short description for
-	 * @return string short description
+	 * Returns short description for a given title.
 	 */
-	public static function getShortDescription( $title ) {
-		$shortDesc = implode( '', self::getPageProps( $title ) );
-		return $shortDesc;
+	public static function getShortDescription( Title $title ): string {
+		return implode( '', self::getPageProps( $title ) );
 	}
 
 	/**
 	 * Look up descriptions (stored in the page wikitext via parser function) for a set of pages.
+	 *
 	 * @param Title[] $titlesByPageId Associative array of page ID => Title object.
 	 * @return string[] Associative array of page ID => description.
 	 */
-	public static function getDescriptionsByPageId( array $titlesByPageId ) {
+	public static function getDescriptionsByPageId( array $titlesByPageId ): array {
 		if ( !$titlesByPageId ) {
 			return [];
 		}
@@ -51,29 +52,23 @@ class HookUtils {
 	}
 
 	/**
-	 * Check if the short description are available for a given title
-	 * @param Title $title
-	 * @return bool
+	 * Check if the short description is available for a given title.
 	 */
-	public static function isAvailableForTitle( $title ): bool {
+	public static function isAvailableForTitle( Title $title ): bool {
 		// Only wikitext pages
 		if ( $title->getContentModel() !== CONTENT_MODEL_WIKITEXT ) {
 			return false;
 		}
-		$hasShortdesc = isset( self::getPageProps( $title )[ $title->getArticleId() ] );
-
-		return $hasShortdesc;
+		return isset( self::getPageProps( $title )[ $title->getArticleId() ] );
 	}
 
 	/**
-	 * Returns ShortDescription config value
-	 * @param string $name config name
-	 * @return string config value
+	 * Returns ShortDescription config value.
 	 */
-	public static function getConfig( $name ) {
-		$config = MediaWikiServices::getInstance()->getConfigFactory()->makeConfig( 'shortdescription' );
-		$configValue = $config->get( $name );
-
-		return $configValue;
+	public static function getConfig( string $name ): mixed {
+		return MediaWikiServices::getInstance()
+			->getConfigFactory()
+			->makeConfig( 'shortdescription' )
+			->get( $name );
 	}
 }

--- a/includes/Hooks/PageHooks.php
+++ b/includes/Hooks/PageHooks.php
@@ -23,27 +23,26 @@ class PageHooks implements BeforePageDisplayHook {
 	private const NATIVE_SKINS = [ 'citizen', 'minerva' ];
 
 	/**
-	 * Add the required javascript to replace the tagline with shortdesc
-	 * @param OutputPage $out OutputPage
+	 * Add the required JavaScript to replace the tagline with the short description.
+	 *
+	 * @param OutputPage $out
 	 * @param Skin $skin
 	 */
 	public function onBeforePageDisplay( $out, $skin ): void {
-		$title = $out->getTitle();
-
-		// Return if tagline is not enabled
 		if ( !HookUtils::getConfig( 'ShortDescriptionEnableTagline' ) ) {
 			return;
 		}
 
-		// Load module if the page is suitable
-		if ( HookUtils::isAvailableForTitle( $title ) ) {
-			// Load module if the skin has no native support
-			if ( !in_array( $skin->getSkinName(), self::NATIVE_SKINS ) ) {
-				$out->addJsConfigVars( 'wgShortDesc', HookUtils::getShortDescription( $title ) );
-				$out->addModules( [
-					'ext.shortDescription'
-				] );
-			}
+		$title = $out->getTitle();
+		if ( !HookUtils::isAvailableForTitle( $title ) ) {
+			return;
 		}
+
+		if ( in_array( $skin->getSkinName(), self::NATIVE_SKINS, true ) ) {
+			return;
+		}
+
+		$out->addJsConfigVars( 'wgShortDesc', HookUtils::getShortDescription( $title ) );
+		$out->addModules( [ 'ext.shortDescription' ] );
 	}
 }

--- a/includes/Hooks/ParserHooks.php
+++ b/includes/Hooks/ParserHooks.php
@@ -23,155 +23,113 @@ class ParserHooks implements
 	ParserFirstCallInitHook
 {
 	/**
-	 * Register property for extensions or skins to use in Outputpage
+	 * Register property for extensions or skins to use in OutputPage.
 	 *
 	 * @param OutputPage $out
-	 * @param ParserOutput $parserOutput ParserOutput instance being added in $out
+	 * @param ParserOutput $parserOutput
 	 */
 	public function onOutputPageParserOutput( $out, $parserOutput ): void {
-		$shortDesc = $parserOutput->getPageProperty( 'shortdesc' );
-
-		// Return if tagline is not enabled
 		if ( !HookUtils::getConfig( 'ShortDescriptionEnableTagline' ) ) {
 			return;
 		}
 
+		$shortDesc = $parserOutput->getPageProperty( 'shortdesc' );
 		$out->setProperty( 'shortdesc', $shortDesc );
 		// Supply description to Minerva
 		$out->setProperty( 'wgMFDescription', $shortDesc );
 	}
 
 	/**
-	 * Register any render callbacks with the parser
+	 * Register render callbacks with the parser.
 	 *
 	 * @param Parser $parser
-	 * @return true
 	 */
 	public function onParserFirstCallInit( $parser ) {
 		$parser->setFunctionHook(
 			'MAG_GETSHORTDESC',
-			[ self::class, 'rendershortdesc' ],
+			self::rendershortdesc( ... ),
 			Parser::SFH_NO_HASH
 		);
 
 		$parser->setFunctionHook(
 			'MAG_SHORTDESC',
-			[ self::class, 'handle' ],
+			self::handle( ... ),
 			Parser::SFH_NO_HASH
 		);
-
-		return true;
 	}
 
 	/**
 	 * Render the output of {{GETSHORTDESC}}.
-	 *
-	 * @param Parser $parser
-	 * @param string $input
-	 * @return string
 	 */
-	public static function rendershortdesc( Parser $parser, $input = '' ) {
-		$output = '';
-
-		// If no title is set then use current page
-		if ( $input ) {
-			$title = Title::newFromText( $input );
-		} else {
-			$title = $parser->getPage();
-		}
+	public static function rendershortdesc( Parser $parser, string $input = '' ): string {
+		$title = $input !== '' ? Title::newFromText( $input ) : $parser->getTitle();
 
 		// Bail if the title cannot be parsed
 		// See https://issue-tracker.miraheze.org/T13055
 		if ( $title === null ) {
-			return $output;
+			return '';
 		}
 
-		// Check if shortdesc exists, render if exist
-		$shortDesc = HookUtils::getShortDescription( $title );
-		if ( $shortDesc !== false ) {
-			$output = $shortDesc;
-		}
-
-		return $output;
+		return HookUtils::getShortDescription( $title );
 	}
 
 	/**
-	 * Extracted from WikiBase
-	 * See T184000 for related info
+	 * Extracted from WikiBase.
+	 * See T184000 for related info.
 	 */
 
 	/**
-	 * Parser function callback
+	 * Parser function callback for {{SHORTDESC:...}}.
 	 *
 	 * @param Parser $parser
 	 * @param string $shortDesc Short description of the current page, as plain text.
-	 *
-	 * @return string
 	 */
-	public static function handle( Parser $parser, $shortDesc ) {
-		$handler = self::factory();
-		$handler->doHandle( $parser, $shortDesc );
+	public static function handle( Parser $parser, string $shortDesc ): string {
+		( new self() )->doHandle( $parser, $shortDesc );
 		return '';
 	}
 
 	/**
-	 * @return self
+	 * Validate a short description.
+	 * Valid descriptions contain something other than whitespace/punctuation.
 	 */
-	private static function factory() {
-		return new self();
-	}
-
-	/**
-	 * Validates a short description.
-	 * Valid descriptions are not empty (contain something other than whitespace/punctuation).
-	 *
-	 * @param string $shortDesc Short description of the current page, as plain text.
-	 *
-	 * @return bool
-	 */
-	public function isValid( $shortDesc ) {
+	public function isValid( string $shortDesc ): bool {
 		return !preg_match( '/^[\s\p{P}\p{Z}]*$/u', $shortDesc );
 	}
 
 	/**
-	 * Sanitizes a short description by converting it into plaintext.
+	 * Sanitize a short description by converting it into plaintext.
 	 *
 	 * Note that the sanitized description can still contain HTML (that was encoded as entities in
-	 * the original) as there is no reason why someone shouldn't mention HTML tags in a description.
+	 * the original) — there is no reason why someone shouldn't mention HTML tags in a description.
 	 * That means the sanitized value is actually less safe for HTML inclusion than the original
-	 * one (can contain <script> tags)! It is clients' responsibility to handle it safely.
+	 * one (can contain <script> tags). It is the client's responsibility to handle it safely.
 	 *
 	 * @param string $shortDesc Short description of the current page, as HTML.
-	 *
 	 * @return string Plaintext of description.
 	 */
-	public function sanitize( $shortDesc ) {
-		// Remove accidental formatting - descriptions are plaintext.
+	public function sanitize( string $shortDesc ): string {
+		// Remove accidental formatting — descriptions are plaintext.
 		$shortDesc = strip_tags( $shortDesc );
-		// Unescape - clients are not necessarily HTML-based and using HTML tags as part of
-		// the descript (i.e. with <nowiki> or such) should be possible.
+		// Unescape — clients are not necessarily HTML-based and using HTML tags as part of the
+		// description (i.e. with <nowiki> or such) should be possible.
 		$shortDesc = html_entity_decode( $shortDesc, ENT_QUOTES, 'utf-8' );
-		// Remove newlines, tabs and other weird whitespace
+		// Remove newlines, tabs and other weird whitespace.
 		$shortDesc = preg_replace( '/\s+/', ' ', $shortDesc );
-		// Get rid of leading/trailing space - no valid usecase for it, easy for it to go unnoticed
+		// Get rid of leading/trailing space — no valid use case for it, easy for it to go unnoticed
 		// in HTML, and clients might display the description in an environment that does not
 		// ignore spaces like HTML does.
 		return trim( $shortDesc );
 	}
 
 	/**
-	 * Parser function
-	 *
-	 * @param Parser $parser
-	 * @param string $shortDesc Short description of the current page, as plain text.
-	 *
-	 * @return void
+	 * Parser function implementation: store the description as a page property
+	 * and add the tracking category.
 	 */
-	public function doHandle( Parser $parser, $shortDesc ) {
+	public function doHandle( Parser $parser, string $shortDesc ): void {
 		$shortDesc = $this->sanitize( $shortDesc );
 		if ( $this->isValid( $shortDesc ) ) {
-			$parserOutput = $parser->getOutput();
-			$parserOutput->setPageProperty( 'shortdesc', $shortDesc );
+			$parser->getOutput()->setPageProperty( 'shortdesc', $shortDesc );
 			$parser->addTrackingCategory( 'shortdescription-category' );
 		}
 	}

--- a/includes/Hooks/RestHooks.php
+++ b/includes/Hooks/RestHooks.php
@@ -19,55 +19,37 @@ class RestHooks implements SearchResultProvideDescriptionHook {
 
 	/**
 	 * Look up descriptions for a set of pages.
-	 * @param Title[] $titles Titles to look up (will be loaded).
-	 * @return string[] Associative array of page ID => description. Pages with no description
-	 *   will be omitted.
+	 *
+	 * @param Title[] $titles Titles to look up.
+	 * @return array<int,?string> Associative array of page ID => description (or null).
 	 */
-	public function getDescriptions( array $titles ) {
-		$pageIds = array_map( static function ( Title $title ) {
-			return $title->getArticleID();
-		}, $titles );
+	public function getDescriptions( array $titles ): array {
+		$pageIds = array_map( static fn ( Title $title ): int => $title->getArticleID(), $titles );
 		$titlesByPageId = array_combine( $pageIds, $titles );
 
-		$descriptions = [];
-		$descriptions += HookUtils::getDescriptionsByPageId( $titlesByPageId );
+		$descriptions = HookUtils::getDescriptionsByPageId( $titlesByPageId );
 
 		// Restore original sort order.
 		$pageIds = array_intersect( $pageIds, array_keys( $descriptions ) );
-		$descriptions = array_replace( array_fill_keys( $pageIds, null ), $descriptions );
-
-		return $descriptions;
+		return array_replace( array_fill_keys( $pageIds, null ), $descriptions );
 	}
 
 	/**
-	 * Look up local descriptions (stored in the page wikitext via parser function) for a set of pages.
-	 * @param Title[] $titlesByPageId Associative array of page ID => Title object.
-	 * @return string[] Associative array of page ID => description.
-	 */
-	private function getLocalDescriptions( array $titlesByPageId ) {
-		if ( !$titlesByPageId ) {
-			return [];
-		}
-		return HookUtils::getPageProps( $titlesByPageId );
-	}
-
-	/**
-	 * Used to update Search Results with descriptions for Search Engine.
-	 * @param array	$pageIdentities	Array (string=>SearchResultPageIdentity) where key is pageId
-	 * @param array &$descriptions Output array (string=>string|null)
-	 * where key is pageId and value is either a description for given page or null
+	 * Update Search Results with descriptions for the search engine.
+	 *
+	 * @param array<int,object> $pageIdentities Array of pageId => SearchResultPageIdentity.
+	 * @param array<int,?string> &$descriptions Output array of pageId => description (or null).
 	 */
 	public function onSearchResultProvideDescription(
 		array $pageIdentities,
 		&$descriptions
 	): void {
-		$pageIdTitles = array_map( static function ( $identity ) {
-			return Title::makeTitle( $identity->getNamespace(), $identity->getDBkey() );
-		}, $pageIdentities );
+		$pageIdTitles = array_map(
+			static fn ( $identity ): Title => Title::makeTitle( $identity->getNamespace(), $identity->getDBkey() ),
+			$pageIdentities
+		);
 
-		$newDescriptions = $this->getDescriptions( $pageIdTitles );
-
-		foreach ( $newDescriptions as $pageId => $description ) {
+		foreach ( $this->getDescriptions( $pageIdTitles ) as $pageId => $description ) {
 			$descriptions[$pageId] = $description;
 		}
 	}


### PR DESCRIPTION
## Summary
- Adds native parameter and return types throughout `includes/`, replacing PHPDoc-only typing.
- Adds `declare(strict_types=1)` to the two files that were missing it (`ApiQueryDescription.php`, `Hooks/HookUtils.php`).
- Switches parser-function callbacks to first-class callable syntax (`self::method(...)` instead of `[self::class, 'method']`).
- Replaces small `array_map`/`array_filter` closures with arrow functions.
- Tightens `HookUtils::getPageProps` signature to `Title|array` to match `PageProps::getProperties`' actual contract, which fixes the latent type imprecision Phan was complaining about earlier.
- Switches `ParserHooks::rendershortdesc` from `$parser->getPage()` (returns `?PageReference`) to `$parser->getTitle()` (returns `?Title`) so the `Title`-typed `HookUtils::getShortDescription` signature is satisfied without a runtime conversion.
- Drops the trivial `factory()` indirection, an unused private `getLocalDescriptions`, and a dead `$pageIds = array_keys(...)` reassignment in `ApiHooks`.
- Collapses a few nested `if`s into early returns for readability.

No behavioural changes — `composer preflight` is green and the live wiki still serves `{{SHORTDESC:...}}` and `{{GETSHORTDESC:...}}` correctly.

## Test plan
- [x] `composer preflight` passes (parallel-lint, phpcs, minus-x, phan)
- [x] `npm run preflight` passes
- [x] API: `?action=query&prop=description&titles=...` returns the description
- [x] Tagline: Citizen renders the description via `BeforePageDisplay`
- [x] `{{GETSHORTDESC:...}}` resolves to the target page's description

🤖 Generated with [Claude Code](https://claude.com/claude-code)